### PR TITLE
add driver rfid to lap data table as a GSI

### DIFF
--- a/packages/amplify/amplify/backend.ts
+++ b/packages/amplify/amplify/backend.ts
@@ -122,6 +122,11 @@ const lapDataTable = new dynamodb.Table(
   },
 );
 
+lapDataTable.addGlobalSecondaryIndex({
+  indexName: "rfid-index",
+  partitionKey: { name: "rfid", type: dynamodb.AttributeType.STRING },
+});
+
 const TelemetryECSTaskDefintion = new ecs.Ec2TaskDefinition(
   TelemetryBackendStack,
   "TelemetryECSTaskDefintion",

--- a/packages/server/src/controllers/BackendController/BackendController.ts
+++ b/packages/server/src/controllers/BackendController/BackendController.ts
@@ -38,9 +38,22 @@ export class BackendController implements BackendControllerTypes {
     logger.info("Car Latency: ", carLatency.toString());
   }
 
+  public handleDriverRFID(driverRFID: string) {
+    if (
+      this.lapController.driverRFID === "" ||
+      this.lapController.driverRFID === driverRFID
+    ) {
+      this.lapController.driverRFID = driverRFID;
+      logger.info("Driver ID Scanned: ", this.lapController.driverRFID);
+    } // if its not set yet, or its different from the last
+  }
+
   public async handlePacketReceive(message: ITelemetryData) {
     // Insert the packet into the database
     this.dynamoDB.insertPacketData(message);
+
+    // check to see if the driver rfid has changed
+    this.handleDriverRFID(message.Other.RFID);
 
     // Broadcast the packet to the frontend
     this.socketIO.broadcastPacket(message);

--- a/packages/server/src/controllers/LapController/LapController.ts
+++ b/packages/server/src/controllers/LapController/LapController.ts
@@ -16,6 +16,7 @@ const logger = createLightweightApplicationLogger("LapController.ts");
 export class LapController implements LapControllerType {
   public lastLapPackets: ITelemetryData[] = [] as ITelemetryData[];
   public previouslyInFinishLineProximity: boolean = false;
+  public driverRFID = "";
   public lapNumber: number = 0;
   public finishLineLocation: Coords = {
     lat: 51.081021,
@@ -76,6 +77,7 @@ export class LapController implements LapControllerType {
           averagePackCurrent,
         ),
         distance: this.getDistanceTravelled(this.lastLapPackets), // CHANGE THIS BASED ON ODOMETER/MOTOR INDEX OR CHANGE TO ITERATE
+        driverRFID: this.driverRFID,
         lapTime: this.calculateLapTime(this.lastLapPackets),
         netPowerOut: this.netPower(this.lastLapPackets),
         timeStamp: packet.TimeStamp,

--- a/packages/server/src/controllers/LapController/LapController.types.ts
+++ b/packages/server/src/controllers/LapController/LapController.types.ts
@@ -14,6 +14,7 @@ export interface LapControllerType {
     motorOdometer: number,
     motorDistanceTraveledSession: number,
   ): boolean;
+  driverRFID: string;
   getAveragePowerIn(packetArray: ITelemetryData[]): number;
   getAveragePowerOut(packetArray: ITelemetryData[]): number;
   getLastPacket(): ITelemetryData[];

--- a/packages/shared/src/functions.ts
+++ b/packages/shared/src/functions.ts
@@ -275,6 +275,9 @@ export function generateFakeTelemetryData(): ITelemetryData {
         TxErrorCount: faker.number.int({ max: 100, min: 0 }),
       },
     ],
+    Other: {
+      RFID: faker.string.uuid(),
+    },
     PacketTitle: faker.lorem.words(2),
     TimeStamp: faker.date.soon().valueOf(),
   };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -33,6 +33,11 @@ export interface ITelemetryData {
   MotorFaults: IMotorFault[];
   PacketTitle: string;
   TimeStamp: number;
+  Other: IOther;
+}
+
+export interface IOther {
+  RFID: string;
 }
 
 export interface ILapData {
@@ -46,6 +51,7 @@ export interface ILapData {
   timeStamp: number;
   totalPowerIn: number;
   totalPowerOut: number;
+  driverRFID: string;
 }
 
 export class LapData {


### PR DESCRIPTION
My thoughts are that when the driver RFID is scanned it just gets added to the packet so I added faker data for that - in backend controller when it is scanned if it is different or hasn't been changed yet (just an empty string be default) then that is when the driver rfid is updated to be put in the table