### PR TITLE
feat: enable ssm access to instances

### DIFF
--- a/packages/amplify/amplify/backend.ts
+++ b/packages/amplify/amplify/backend.ts
@@ -190,6 +190,7 @@ const ec2Role = new iam.Role(TelemetryBackendStack, "TelemetryDBEC2Role", {
       "AmazonEC2ContainerRegistryReadOnly",
     ),
     iam.ManagedPolicy.fromAwsManagedPolicyName("SecretsManagerReadWrite"),
+    iam.ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore"), // allows users to connect to instance using AWS SSM
   ],
 });
 
@@ -230,6 +231,21 @@ const keyPair = ec2.KeyPair.fromKeyPairName(
   "KeyPair",
   "Burton",
 );
+// policy to allow users to connect to instance via ssm, we can use this in the future to grant users permissions to start a session
+// add this policy in the future to users' roles so they can start an ssm session to connect to the instance instead of having to
+// create a .pem file and allow specific ips / users to connect we use this instead.
+const ssmUserPolicy = new iam.Policy(TelemetryBackendStack, "SSMUserPolicy", {
+  statements: [
+    new iam.PolicyStatement({
+      actions: [
+        "ssm:StartSession",
+        "ssm:DescribeSessions",
+        "ssm:GetConnectionStatus",
+      ],
+      resources: ["*"], // allow on all instances; you can narrow this later
+    }),
+  ],
+});
 
 const dbInstance = new ec2.Instance(
   TelemetryBackendStack,


### PR DESCRIPTION
### Summary
- So instead of connecting solely using .pem files or specific ips, we can let the instance be connected via SSM 
[link](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html)

This was the way I've connected to instances in the past where you connect via the session manager using the following command from your aws console on your local:
`aws ssm start-session --target <instance-id>`


Then from here you can scp the DB so that you can develop and tinker with it on your local

My bad, honestly forgot this was a thing 😆 

