### PR TITLE
fix: environment variable file creation and mount volume correctly

### DIFF
--- a/packages/amplify/amplify/backend.ts
+++ b/packages/amplify/amplify/backend.ts
@@ -313,12 +313,12 @@ DB_CREDS=$(aws secretsmanager get-secret-value --secret-id $SECRET_NAME --query 
 POSTGRES_USERNAME=$(echo $DB_CREDS | jq -r .POSTGRES_USERNAME)
 POSTGRES_PASSWORD=$(echo $DB_CREDS | jq -r .POSTGRES_PASSWORD)
 
-# Create .env file for Docker Compose
-cat <<EOF > /home/ec2-user/Helios-Telemetry/packages/db/.db.env
-POSTGRES_USER=$POSTGRES_USERNAME
-POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+# Create .env file for Docker Compose has to use sudo sh for permissions
+sudo sh -c 'cat <<EOF > /home/ec2-user/Helios-Telemetry/packages/db/.db.env
+POSTGRES_USER='"$POSTGRES_USERNAME"'
+POSTGRES_PASSWORD='"$POSTGRES_PASSWORD"'
 POSTGRES_DB=postgres
-EOF
+EOF'
 
 # Run Docker Compose
 sudo curl -L "https://github.com/docker/compose/releases/download/v2.23.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/packages/db/docker-compose.yml
+++ b/packages/db/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 
 services:
   db:
@@ -6,10 +6,8 @@ services:
     env_file:
       - .db.env # contains the information regarding our user, password, and database
     ports:
-      - "5432:5432" # map host port to internal port 
+      - "5432:5432" # map host port to internal port
     volumes:
-      - db-data:/var/lib/postgresql/data # volume to store persistence in case the container spins down/fails etc
+      - /var/lib/timescaledb/data:/var/lib/postgresql/data # volume to store persistence in case the container spins down/fails etc
     restart: unless-stopped # try to restart it unless manually stopped
 
-volumes:
-  db-data:  # named volume for persistent DB storage


### PR DESCRIPTION
### Summary
- Fixed `.db.env` creation in `docker-compose.yml` by adjusting file permissions.
- Docker named volumes default to the EC2 root filesystem, so the EBS volume wasn’t being used.
- Added bind mount to ensure the container stores database data on the EBS volume.
