### PR TITLE
fix: timescale's connector's password env variable

### DIFF
--- a/packages/db/src/data-source.ts
+++ b/packages/db/src/data-source.ts
@@ -24,5 +24,5 @@ export const AppDataSource = new DataSource({
   port: parseInt(process.env.DB_PORT || "5432"),
   synchronize: process.env.NODE_ENV === "development", // Only in development
   type: "postgres",
-  username: process.env.POSTGRES_USER || "postgres",
+  username: process.env.POSTGRES_USERNAME || "postgres",
 });


### PR DESCRIPTION
Summary
- Minor fix to update the backend service to use the correct environment variable for the db's password.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration environment variable naming convention for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->