### PR TITLE
feat: add example environment variables for server package

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,0 +1,56 @@
+# Example environment variables for the server package
+# Copy this file to .env.local (or .env) and fill in real values.
+# DO NOT commit real secrets. This file contains only example placeholders.
+
+########################
+# Database (DynamoDB)  #
+########################
+LAP_TABLE_NAME="your-dynamodb-lap-table-name"
+PACKET_TABLE_NAME="your-dynamodb-packet-table-name"
+DRIVER_TABLE_NAME="your-dynamodb-driver-table-name"
+GPS_CALCULATED_LAP_DATA_TABLE="your-dynamodb-gps-lap-table-name"
+GPS_TABLE_NAME="your-dynamodb-gps-table-name"
+
+########################
+# Loki / Logger        #
+########################
+# When LOKI_URL is set the server will POST logs to Loki's push API.
+LOKI_URL="" # e.g. "https://loki.example.com" or "http://loki:3100"
+
+# Authentication options (choose one):
+# 1) Provide a base64 encoded username:password
+LOKI_BASIC_AUTH="" # e.g. "dXNlcjpwYXNzd29yZA=="
+# OR
+# 2) Provide username/password and the logger will encode them automatically
+LOKI_USERNAME=""
+LOKI_PASSWORD=""
+
+# Optional static labels for Loki streams (comma-separated key=value)
+# Example: "app=helios,env=development,team=ucsolarcar"
+LOKI_LABELS=""
+
+########################
+# MQTT                 #
+########################
+MQTT_USERNAME="primaryuser"
+MQTT_PASSWORD="changeme"
+
+########################
+# App secrets / other  #
+########################
+LAP_POSITION_PASSWORD="changeme"
+NEXT_PUBLIC_MAPSAPIKEY="pk.YOUR_PUBLIC_MAP_KEY_HERE"
+
+########################
+# Local logging / misc #
+########################
+LOG_DIR="logs"
+LOG_FILE="app.log"
+LOG_LEVEL="info"      # e.g. "debug", "info", "warn", "error"
+LOG_ERROR_STACK="false" # When "true", include error stacks in console output
+
+########################
+# Node / Environment   #
+########################
+NODE_ENV="development"
+ENV="development"


### PR DESCRIPTION
Environment variables can be accessed [here](https://uofcsolarcar.atlassian.net/wiki/spaces/ST/pages/345964547/Helios+Telemetry+Environment+Variables
) if you have the correct permissions. Reach out to your team lead if you are missing some. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a server environment configuration template with placeholders and guidance for database names, logging integration (Loki), MQTT settings, application secrets, maps API key, log options, and Node/DVEL environment flags to simplify local and deployment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->