### PR TITLE
Add AverageMotorWattage field to lap data and implement calculation method

### DIFF
--- a/packages/client/src/stores/useLapData.ts
+++ b/packages/client/src/stores/useLapData.ts
@@ -6,6 +6,7 @@ import { IFormattedLapData, ILapData, prodURL } from "@shared/helios-types";
 
 export const formatLapData = (lapPacket: ILapData): IFormattedLapData => ({
   AmpHours: parseFloat(lapPacket.AmpHours.toFixed(2)),
+  AverageMotorWattage: parseFloat(lapPacket.AverageMotorWattage.toFixed(2)),
   AveragePackCurrent: parseFloat(lapPacket.AveragePackCurrent.toFixed(2)),
   AverageSpeed: parseFloat(lapPacket.AverageSpeed.toFixed(2)),
   BatterySecondsRemaining: parseFloat(

--- a/packages/db/src/entities/Lap.entity.ts
+++ b/packages/db/src/entities/Lap.entity.ts
@@ -46,4 +46,7 @@ export class Lap {
 
   @Column({ type: "float" })
   AverageSpeed!: number;
+
+  @Column({ type: "float" })
+  AverageMotorWattage!: number;
 }

--- a/packages/server/src/controllers/LapController/LapController.ts
+++ b/packages/server/src/controllers/LapController/LapController.ts
@@ -503,7 +503,7 @@ export class LapController implements LapControllerType {
       return sum + wattage;
     }, 0);
 
-    return totalWattage;
+    return totalWattage / packetArray.length;
   }
 
   public getAveragePowerOut(packetArray: ITelemetryData[]): number {

--- a/packages/server/src/controllers/LapController/LapController.ts
+++ b/packages/server/src/controllers/LapController/LapController.ts
@@ -246,6 +246,9 @@ export class LapController implements LapControllerType {
         AverageSpeed: this.calculateAverageLapSpeed(
           this.lastLapPackets.toArray(),
         ),
+        AverageMotorWattage: this.getAverageMotorWattage(
+          this.lastLapPackets.toArray(),
+        ),
         BatterySecondsRemaining: this.getSecondsRemainingUntilChargedOrDepleted(
           averagePackCurrent,
           amphoursValue,
@@ -480,6 +483,27 @@ export class LapController implements LapControllerType {
     const avgRegenPower = regenPowerSum / packetArray.length;
 
     return Math.abs(mpptPowerIn + avgRegenPower);
+  }
+
+  public getAverageMotorWattage(packetArray: ITelemetryData[]): number {
+    // If no packets, then no power out
+    if (packetArray.length === 0) {
+      return 0;
+    }
+
+    const totalWattage = packetArray.reduce((sum, packet) => {
+      let wattage = 0;
+
+      const motorDetails = [packet.MotorDetails0, packet.MotorDetails1];
+
+      for (const motor of motorDetails) {
+        wattage += motor.BusCurrent * motor.BusVoltage;
+      }
+
+      return sum + wattage;
+    }, 0);
+
+    return totalWattage;
   }
 
   public getAveragePowerOut(packetArray: ITelemetryData[]): number {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -420,6 +420,7 @@ export interface IDriverData {
 
 export interface ILapData {
   AmpHours: number;
+  AverageMotorWattage: number;
   AveragePackCurrent: number;
   AverageSpeed: number;
   BatterySecondsRemaining: number;
@@ -486,6 +487,7 @@ export interface IRaceInfo {
 
 export interface IFormattedLapData {
   AmpHours: number;
+  AverageMotorWattage: number;
   AveragePackCurrent: number;
   AverageSpeed: number;
   BatterySecondsRemaining: number;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -491,6 +491,7 @@ export interface IFormattedLapData {
   AverageMotorWattage: number;
   AveragePackCurrent: number;
   AverageSpeed: number;
+  AverageMotorWattage: number;
   BatterySecondsRemaining: number;
   Distance: number;
   EnergyConsumed: number;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -423,6 +423,7 @@ export interface ILapData {
   AverageMotorWattage: number;
   AveragePackCurrent: number;
   AverageSpeed: number;
+  AverageMotorWattage: number;
   BatterySecondsRemaining: number;
   Distance: number;
   EnergyConsumed: number;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -423,7 +423,6 @@ export interface ILapData {
   AverageMotorWattage: number;
   AveragePackCurrent: number;
   AverageSpeed: number;
-  AverageMotorWattage: number;
   BatterySecondsRemaining: number;
   Distance: number;
   EnergyConsumed: number;
@@ -491,7 +490,6 @@ export interface IFormattedLapData {
   AverageMotorWattage: number;
   AveragePackCurrent: number;
   AverageSpeed: number;
-  AverageMotorWattage: number;
   BatterySecondsRemaining: number;
   Distance: number;
   EnergyConsumed: number;


### PR DESCRIPTION
### Screenshot
<img width="1090" height="640" alt="Screenshot 2026-03-14 at 4 15 05 PM" src="https://github.com/user-attachments/assets/c42132d1-dd93-4557-924d-a5c3b255e00d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lap data now includes an Average Motor Wattage metric stored per lap.
  * The metric is computed from motor telemetry and gracefully handles empty/missing data.
  * The metric is persisted with lap records and shown in formatted lap results, rounded to two decimal places for easier energy and performance analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->