### PR TITLE
fix: fix user latency experience

### DIFF
--- a/packages/client/src/components/global/AppStateEffectsManager.tsx
+++ b/packages/client/src/components/global/AppStateEffectsManager.tsx
@@ -114,35 +114,78 @@ export default function AppStateEffects() {
   const { currentAppState, setCurrentAppState } = useAppState();
 
   useEffect(() => {
-    if (currentAppState.connectionType === CONNECTIONTYPES.DEMO) {
-      if (currentAppState.socketConnected) {
-        setCurrentAppState((prev) => ({
+    setCurrentAppState((prev) => {
+      if (
+        prev.connectionType === CONNECTIONTYPES.NETWORK &&
+        (!prev.mqttConnected || !prev.socketConnected)
+      ) {
+        return {
           ...prev,
-          connectionType: CONNECTIONTYPES.NETWORK,
+          connectionType: CONNECTIONTYPES.DEMO,
           loading: false,
-        }));
+        };
       }
-      if (currentAppState.radioConnected) {
-        setCurrentAppState((prev) => ({
+
+      if (
+        prev.connectionType === CONNECTIONTYPES.RADIO &&
+        !prev.radioConnected
+      ) {
+        return {
           ...prev,
-          connectionType: CONNECTIONTYPES.RADIO,
+          connectionType: CONNECTIONTYPES.DEMO,
           loading: false,
-        }));
+        };
       }
-    }
-    if (currentAppState.connectionType === CONNECTIONTYPES.NETWORK) {
-      setCurrentAppState((prev) => ({
-        ...prev,
-        loading: !currentAppState.socketConnected,
-      }));
-    }
-    if (currentAppState.connectionType === CONNECTIONTYPES.RADIO) {
-      setCurrentAppState((prev) => ({
-        ...prev,
-        loading: !currentAppState.radioConnected,
-      }));
-    }
+
+      if (prev.connectionType === CONNECTIONTYPES.DEMO) {
+        if (prev.mqttConnected) {
+          return {
+            ...prev,
+            connectionType: CONNECTIONTYPES.NETWORK,
+            loading: false,
+          };
+        }
+
+        if (prev.radioConnected) {
+          return {
+            ...prev,
+            connectionType: CONNECTIONTYPES.RADIO,
+            loading: false,
+          };
+        }
+
+        if (prev.loading) {
+          return {
+            ...prev,
+            loading: false,
+          };
+        }
+      }
+
+      if (prev.connectionType === CONNECTIONTYPES.NETWORK) {
+        const nextLoading = !prev.socketConnected;
+        if (prev.loading !== nextLoading) {
+          return {
+            ...prev,
+            loading: nextLoading,
+          };
+        }
+      }
+
+      if (prev.connectionType === CONNECTIONTYPES.RADIO) {
+        const nextLoading = !prev.radioConnected;
+        if (prev.loading !== nextLoading) {
+          return {
+            ...prev,
+            loading: nextLoading,
+          };
+        }
+      }
+
+      return prev;
+    });
   }, [
+    currentAppState.mqttConnected,
     currentAppState.socketConnected,
     currentAppState.radioConnected,
     setCurrentAppState,

--- a/packages/client/src/components/global/AppStateEffectsManager.tsx
+++ b/packages/client/src/components/global/AppStateEffectsManager.tsx
@@ -138,7 +138,7 @@ export default function AppStateEffects() {
       }
 
       if (prev.connectionType === CONNECTIONTYPES.DEMO) {
-        if (prev.mqttConnected) {
+        if (prev.mqttConnected && prev.socketConnected) {
           return {
             ...prev,
             connectionType: CONNECTIONTYPES.NETWORK,

--- a/packages/client/src/components/global/SocketManager.tsx
+++ b/packages/client/src/components/global/SocketManager.tsx
@@ -68,7 +68,11 @@ export default function SocketManager() {
   }, [setCurrentAppState]);
 
   const onCarDisconnect = useCallback(() => {
-    setCurrentAppState((prev) => ({ ...prev, mqttConnected: false }));
+    setCurrentAppState((prev) => ({
+      ...prev,
+      carLatency: 0,
+      mqttConnected: false,
+    }));
     notifications.show({
       color: "red",
       message: "Car has disconnected!",
@@ -100,7 +104,11 @@ export default function SocketManager() {
     });
 
     socketIO.on("disconnect", () => {
-      setCurrentAppState((prev) => ({ ...prev, socketConnected: false }));
+      setCurrentAppState((prev) => ({
+        ...prev,
+        socketConnected: false,
+        userLatency: 0,
+      }));
     });
 
     return () => {

--- a/packages/client/src/components/molecules/LogoStatusMolecules/SettingsComponent.tsx
+++ b/packages/client/src/components/molecules/LogoStatusMolecules/SettingsComponent.tsx
@@ -184,7 +184,7 @@ function SettingsComponent() {
                   (key) => {
                     const disabled =
                       (key === CONNECTIONTYPES.NETWORK &&
-                        !currentAppState.socketConnected) ||
+                        !currentAppState.mqttConnected) ||
                       (key === CONNECTIONTYPES.RADIO &&
                         !currentAppState.radioConnected);
 
@@ -213,7 +213,7 @@ function SettingsComponent() {
                   (key) => {
                     const disabledText =
                       (key === CONNECTIONTYPES.NETWORK &&
-                        !currentAppState.socketConnected &&
+                        !currentAppState.mqttConnected &&
                         "Can not connect to AWS") ||
                       (key === CONNECTIONTYPES.RADIO &&
                         !currentAppState.radioConnected &&

--- a/packages/client/src/components/molecules/LogoStatusMolecules/SettingsComponent.tsx
+++ b/packages/client/src/components/molecules/LogoStatusMolecules/SettingsComponent.tsx
@@ -214,10 +214,10 @@ function SettingsComponent() {
                     const disabledText =
                       (key === CONNECTIONTYPES.NETWORK &&
                         !currentAppState.mqttConnected &&
-                        "Can not connect to AWS") ||
+                        "Unable to connect to the car") ||
                       (key === CONNECTIONTYPES.RADIO &&
                         !currentAppState.radioConnected &&
-                        "Can not connect to USB Radio Board");
+                        "Unable to connect to USB Radio Board");
 
                     return (
                       <div

--- a/packages/client/src/components/molecules/LogoStatusMolecules/StatusComponent.tsx
+++ b/packages/client/src/components/molecules/LogoStatusMolecules/StatusComponent.tsx
@@ -35,11 +35,12 @@ function PlaybackPickerComponent() {
 function StatusComponent() {
   const { currentAppState } = useAppState();
   const { currentPacket } = usePacketStore();
-  const userConnection = currentAppState.socketConnected;
   const { resolvedTheme } = useTheme();
-  // TODO: change carConnection from socketIO.connected to carConnection.connected
+
+  const userConnection = currentAppState.socketConnected;
   const carConnection = currentAppState.mqttConnected;
   const colorTheme = resolvedTheme === "dark" ? "white" : "black";
+
   // Maybe server should have a reference to the last packet received from the vehicle.
   const packetTime = currentAppState.socketConnected
     ? new Date(currentPacket.TimeStamp).toLocaleString()

--- a/packages/client/src/components/molecules/LogoStatusMolecules/StatusComponent.tsx
+++ b/packages/client/src/components/molecules/LogoStatusMolecules/StatusComponent.tsx
@@ -38,7 +38,7 @@ function StatusComponent() {
   const userConnection = currentAppState.socketConnected;
   const { resolvedTheme } = useTheme();
   // TODO: change carConnection from socketIO.connected to carConnection.connected
-  const carConnection = currentAppState.socketConnected;
+  const carConnection = currentAppState.mqttConnected;
   const colorTheme = resolvedTheme === "dark" ? "white" : "black";
   // Maybe server should have a reference to the last packet received from the vehicle.
   const packetTime = currentAppState.socketConnected


### PR DESCRIPTION
when the car/server is disconnected, will automatically go to demo mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated app state updates for more reliable transitions and loading indicators across connection modes.
  * Reset car and user latency values when their respective connections disconnect.
  * Adjusted connection status indicators and messages (e.g., "Unable to connect to the car" and USB radio messaging) to better reflect MQTT vs socket connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->